### PR TITLE
Feature/pyimgui support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 `pyvista-imgui` is a small helper module for the [`pyvista`](https://github.com/pyvista/pyvista)-package to integrate it with the [imgui](https://github.com/ocornut/imgui)-library. 
 
-It integrates a fully interactive `pyvista`-Plotter as an imgui-widget, by utilizing VTK's `vtkGenericOpenGLRenderWindow` to first render the output into an OpenGL texture and displaying it as a regular imgui-Image widget.
+It integrates a fully interactive `pyvista`-Plotter as an imgui-widget, by utilizing VTK's `vtkGenericOpenGLRenderWindow` to first render the output into an OpenGL texture and displaying it as a regular imgui-image widget.
 
-It currently utilizes the bindings provided by [`imgui-bundle`](https://github.com/ocornut/imgui), but the integration of other imgui-bindings is planned for a future release.
+It currently utilizes either the bindings provided by [`imgui-bundle`](https://github.com/ocornut/imgui), or by [`pyimgui`](https://github.com/pyimgui/pyimgui/tree/master).
 
 This package is considered experimental at this moment, so expect issues.
 
@@ -15,15 +15,23 @@ This package is considered experimental at this moment, so expect issues.
 To install this package using `pip` use:
 
 ```bash
-pip install pyvista-imgui
+pip install pyvista-imgui[imgui-bundle]
 ```
+
+for the `imgui-bundle` bindings or:
+
+```bash
+pip install pyvista-imgui[imgui]
+```
+
+for the `pyimgui` bindings.
 
 Alternatively the installation from source is also possible with:
 
 ```bash
 git clone https://github.com/mortacious/pyvista-imgui
 cd pyvista-imgui
-pip install [-e] .
+pip install [-e] .[imgui-bundle / imgui] 
 ```
 
 ## Usage
@@ -42,7 +50,7 @@ plotter.add_mesh(sphere)
 plotter.show()
 ```
 
-Alternatively, an instance of `ImguiPlotter` can be integrated into an existing `imgui`-UI as a widget:
+Alternatively, an instance of `ImguiPlotter` can be integrated into an existing imgui-UI as a widget:
 
 ```py
 imgui.begin("Imgui Plotter")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,8 @@ dynamic = ["version"]
 imgui-bundle = [
   'imgui-bundle'
 ]
-pyimgui = [
-  'imgui'
+imgui = [
+  'imgui[glfw]'
 ]
 
 [tool.setuptools_scm]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,11 +27,18 @@ classifiers = [
 dependencies = [
     "pyvista>=0.39",
     'vtk', # without version
-    'imgui-bundle',
     'PyOpenGL',
     'importlib-metadata; python_version>"3.8"',
 ]
 dynamic = ["version"]
+
+[project.optional-dependencies]
+imgui-bundle = [
+  'imgui-bundle'
+]
+pyimgui = [
+  'imgui'
+]
 
 [tool.setuptools_scm]
 write_to = "pyvista_imgui/_version.py"

--- a/pyvista_imgui/imgui_render_window.py
+++ b/pyvista_imgui/imgui_render_window.py
@@ -1,18 +1,26 @@
 from .texture_render_window import VTKOpenGLTextureRenderWindow
 from vtkmodules.vtkRenderingUI import vtkGenericRenderWindowInteractor
 from vtkmodules.vtkCommonCore import vtkCommand
+import enum
+
+BACKEND_IMGUI_BUNDLE = 0
+BACKEND_PYIMGUI = 1
+
 try:
     from imgui_bundle import imgui
-    _imgui_bundle = True
+    _imgui_backend = BACKEND_IMGUI_BUNDLE
 except ImportError:
     # fall back to the pyimgui package
-    import imgui
-    _imgui_bundle = False
+    try:
+        import imgui
+        _imgui_backend = BACKEND_PYIMGUI
+    except ImportError:
+        raise ImportError("Could not find a supported imgui package.")
 
 
 import typing as typ
 
-__all__ = ['VTKImguiRenderWindowInteractor']
+__all__ = ['VTKImguiRenderWindowInteractor', 'BACKEND_IMGUI_BUNDLE', 'BACKEND_PYIMGUI']
 
 
 class VTKImguiRenderWindowInteractor(object):
@@ -31,7 +39,7 @@ class VTKImguiRenderWindowInteractor(object):
     """
     def __init__(self, 
                  border: bool = False) -> None:
-            
+        self.imgui_backed = _imgui_backend
         self.border = border
         self.renwin = VTKOpenGLTextureRenderWindow(viewport_size=(0, 0))
 
@@ -110,7 +118,7 @@ class VTKImguiRenderWindowInteractor(object):
             the size of the result in the ui in pixels, 
             if None (default) the maximum available size is used.
         """
-        if _imgui_bundle:
+        if self.imgui_backed == BACKEND_IMGUI_BUNDLE:
             self._render_imgui_bundle(size)
         else:
             self._render_pyimgui(size)
@@ -180,7 +188,7 @@ class VTKImguiRenderWindowInteractor(object):
         
         self.interactor.SetEventInformationFlipY(xpos, ypos, ctrl, shift, chr(0), 0, None)
 
-        if _imgui_bundle:
+        if self.imgui_backed == BACKEND_IMGUI_BUNDLE:
             self._process_events_imgui_bundle(io)
         else:
             self._process_events_pyimgui(io)

--- a/pyvista_imgui/imgui_render_window.py
+++ b/pyvista_imgui/imgui_render_window.py
@@ -1,6 +1,5 @@
 from .texture_render_window import VTKOpenGLTextureRenderWindow
 from vtkmodules.vtkRenderingUI import vtkGenericRenderWindowInteractor
-from vtkmodules.vtkRenderingCore import vtkRenderer
 from vtkmodules.vtkCommonCore import vtkCommand
 try:
     from imgui_bundle import imgui
@@ -32,7 +31,7 @@ class VTKImguiRenderWindowInteractor(object):
     """
     def __init__(self, 
                  border: bool = False) -> None:
-
+            
         self.border = border
         self.renwin = VTKOpenGLTextureRenderWindow(viewport_size=(0, 0))
 

--- a/pyvista_imgui/plotting.py
+++ b/pyvista_imgui/plotting.py
@@ -1,16 +1,9 @@
 import pyvista as pv
-from .imgui_render_window import VTKImguiRenderWindowInteractor
+from .imgui_render_window import VTKImguiRenderWindowInteractor, BACKEND_IMGUI_BUNDLE, BACKEND_PYIMGUI
 from pyvista import global_theme
 from pyvista.plotting.render_window_interactor import RenderWindowInteractor
 import typing as typ
 from functools import wraps
-try:
-    from imgui_bundle import imgui
-    _imgui_bundle = True
-except ImportError:
-    # fall back to the pyimgui package
-    import imgui
-    _imgui_bundle = False
 
 __all__ = ['ImguiPlotter']
 
@@ -164,7 +157,7 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
             The size of the displayed window, by default (1400, 1080)
         """
 
-        from imgui_bundle import immapp, hello_imgui     
+        from imgui_bundle import immapp, hello_imgui, imgui     
         runner_params = hello_imgui.RunnerParams()
         runner_params.app_window_params.window_title = title or "ImguiPlotter"
         runner_params.app_window_params.window_geometry.size = window_size
@@ -199,6 +192,7 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
         """
         import glfw
         import OpenGL.GL as GL
+        import imgui
         from imgui.integrations.glfw import GlfwRenderer
 
         if not glfw.init():
@@ -273,7 +267,7 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
             before_close_callback = global_theme._before_close_callback
         self._before_close_callback = before_close_callback
 
-        if _imgui_bundle:
+        if self.imgui_backed == BACKEND_IMGUI_BUNDLE:
             self._show_imgui_bundle(title=title, window_size=window_size)
         else:
             self._show_pyimgui(title=title, window_size=window_size)

--- a/pyvista_imgui/plotting.py
+++ b/pyvista_imgui/plotting.py
@@ -204,14 +204,7 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
         if not glfw.init():
             raise ValueError("Could not initialize OpenGL context")
 
-        # OS X supports only forward-compatible core profiles from 3.2
-        #glfw.window_hint(glfw.CONTEXT_VERSION_MAJOR, 3)
-        #glfw.window_hint(glfw.CONTEXT_VERSION_MINOR, 3)
-        #glfw.window_hint(glfw.OPENGL_PROFILE, glfw.OPENGL_CORE_PROFILE)
-
-        #glfw.window_hint(glfw.OPENGL_FORWARD_COMPAT, GL.GL_TRUE)
-
-        # Create a windowed mode window and its OpenGL context
+        # Create a window and its OpenGL context
         window = glfw.create_window(int(window_size[0]), int(window_size[1]), title or "ImguiPlotter", None, None)
         glfw.make_context_current(window)
 


### PR DESCRIPTION
This adds support for the imgui bindings provided by the `pyimgui` package in addition to the existing `imgui-bundle` bindings.  The `imgui-bundle` bindings are used by default and the implementation falls back to `pyimgui` automatically. 