### PR TITLE
Use VTK fbo for rendering

### DIFF
--- a/example/example_embedded.py
+++ b/example/example_embedded.py
@@ -24,7 +24,7 @@ def gui():
     imgui.begin("Imgui Plotter", flags=imgui.WindowFlags_.no_bring_to_front_on_focus | imgui.WindowFlags_.no_title_bar | imgui.WindowFlags_.no_decoration | imgui.WindowFlags_.no_resize | imgui.WindowFlags_.no_move)
 
     # render the plotter's contents here
-    plotter.render()
+    plotter.render_imgui()
 
     imgui.end()
     imgui.show_demo_window()

--- a/example/example_standalone.py
+++ b/example/example_standalone.py
@@ -3,7 +3,7 @@ from pyvista_imgui import ImguiPlotter
 
 sphere = pv.Sphere()
 
-plotter = ImguiPlotter(backend='imgui_bundle')
+plotter = ImguiPlotter(imgui_backend='imgui_bundle')
 plotter.add_axes()
 plotter.add_mesh(sphere, render=False)
 plotter.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ classifiers = [
 dependencies = [
     "pyvista>=0.39",
     'vtk', # without version
-    'PyOpenGL',
     'importlib-metadata; python_version>"3.8"',
 ]
 dynamic = ["version"]

--- a/pyvista_imgui/_backend_imgui_bundle.py
+++ b/pyvista_imgui/_backend_imgui_bundle.py
@@ -248,4 +248,5 @@ class RendererBackendImguiBundle(RendererBackend):
         runner_params.callbacks.show_gui = gui
         runner_params.imgui_window_params.default_imgui_window_type = hello_imgui.DefaultImGuiWindowType.no_default_window
         immapp.run(runner_params=runner_params)
+        
       

--- a/pyvista_imgui/_backend_imgui_bundle.py
+++ b/pyvista_imgui/_backend_imgui_bundle.py
@@ -111,13 +111,12 @@ class RendererBackendImguiBundle(RendererBackend):
             raise ModuleNotFoundError(f"{self.__class__.__name__} requires the 'imgui_bundle' package.")
         super().__init__(interactor, render_window, border=border)
 
-    def render(self, size: tuple[int, int] | None = None):
-        if size is None:
-            # get the maximum available size
-            size = imgui.get_content_region_avail()
-            size = (size.x, size.y)
-
-        self.render_window.render(size)
+    def render(self, size: typ.Optional[tuple[int, int]] = None):
+        # get the maximum available size
+        size = size or imgui.get_content_region_avail()
+        size = (size.x, size.y)
+        self.render_window.size = size
+        self.render_window.render()
 
         # adjust the size of this interactor as well
         self.interactor.SetSize(int(size[0]), int(size[1]))

--- a/pyvista_imgui/_backend_pyimgui.py
+++ b/pyvista_imgui/_backend_pyimgui.py
@@ -20,13 +20,13 @@ class RendererBackendPyImgui(RendererBackend):
             raise ModuleNotFoundError(f"{self.__class__.__name__} requires the 'pyimgui' package.")
         super().__init__(interactor, render_window, border=border)
 
-    def render(self, size: tuple[int, int] | None = None):
-        if size is None:
-            # get the maximum available size
-            size = imgui.get_content_region_available()
-            size = (size.x, size.y)
-
-        self.render_window.render(size)
+    def render(self):
+        #if size is None:
+        # get the maximum available size
+        size = imgui.get_content_region_available()
+        size = (size.x, size.y)
+        self.render_window.size = size
+        self.render_window.render()
 
         # adjust the size of this interactor as well
         self.interactor.SetSize(int(size[0]), int(size[1]))

--- a/pyvista_imgui/imgui_render_window.py
+++ b/pyvista_imgui/imgui_render_window.py
@@ -81,6 +81,9 @@ class VTKImguiRenderWindowInteractor(object):
         # do not render unless explicitly requested, as imgui has control over the event loop
         self.interactor.EnableRenderOff()
         self.renwin.SetInteractor(self.interactor)
+
+    def close(self):
+        self.renwin.close()
     
     def __getattr__(self, attr):
         """

--- a/pyvista_imgui/plotting.py
+++ b/pyvista_imgui/plotting.py
@@ -146,6 +146,8 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
             if _ALL_PLOTTERS is not None:
                 _ALL_PLOTTERS.pop(self._id_name, None)
 
+        VTKImguiRenderWindowInteractor.close(self)
+
         # this helps managing closed plotters
         self._closed = True 
 
@@ -176,12 +178,16 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
         kwargs: Exists to ensure compatiblity with the BasePlotter interface. 
                 Any additional keywords are ignored for this plotter.
         """
+        if self._closed:
+            raise ValueError("Attempt to re-open a closed plotter")
+        
         if before_close_callback is None:
             before_close_callback = global_theme._before_close_callback
         self._before_close_callback = before_close_callback
 
         def _show():
             self.imgui_backend.show(title=self.title, window_size=window_size)
+            self.close()
 
         if self._background:
             from threading import Thread

--- a/pyvista_imgui/plotting.py
+++ b/pyvista_imgui/plotting.py
@@ -4,9 +4,19 @@ from pyvista import global_theme
 from pyvista.plotting.render_window_interactor import RenderWindowInteractor
 import typing as typ
 from functools import wraps
+import contextlib
 
 __all__ = ['ImguiPlotter']
 
+
+@contextlib.contextmanager
+def _no_base_plotter_init():
+    init = pv.BasePlotter.__init__
+    pv.BasePlotter.__init__ = lambda *args, **kwargs: None
+    try:
+        yield
+    finally:
+        pv.BasePlotter.__init__ = init
 
 class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
     """
@@ -35,58 +45,103 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
     background, optional
         Spawn the viewer in a background thread to allow the main python interpreter to continue. 
         Only works when calling 'show'
+    imgui_backend, optional
+        The imgui backend to use for the ui. Use either 'pyimgui' or 'imgui_bundle'.
     """
 
     def __init__(self, 
                  title=None,
-                 multi_samples: int = None,
+                 window_size=None,
                  line_smoothing: bool = False,
                  point_smoothing: bool = False,
                  polygon_smoothing: bool = False,
                  background: bool = False,
-                 backend: typ.Optional[str] = None,
+                 imgui_backend: typ.Optional[str] = None,
                  **kwargs):
-
+        
+        self._initialized = False
+        
         # imgui has it's own border functionality so ignore the vtk one
         border = kwargs.pop("border", False)
-
-        VTKImguiRenderWindowInteractor.__init__(self, border=border, backend=backend)
+        with _no_base_plotter_init():
+            VTKImguiRenderWindowInteractor.__init__(self, border=border, imgui_backend=imgui_backend)
         pv.BasePlotter.__init__(self, **kwargs)
-
-        if multi_samples is None:
-            multi_samples = global_theme.multi_samples
-
-        self.renwin.SetMultiSamples(multi_samples)
-
         self.title = title or "ImguiPlotter"
+        self.suppress_rendering = True # disable rendering as the event loop is controlled by imgui
+
+        self.render_window.SetMultiSamples(0)
         if line_smoothing:
-            self.renwin.LineSmoothingOn()
+            self.render_window.LineSmoothingOn()
         if point_smoothing:
-            self.renwin.PointSmoothingOn()
+            self.render_window.PointSmoothingOn()
         if polygon_smoothing:
-            self.renwin.PolygonSmoothingOn()
+            self.render_window.PolygonSmoothingOn()
 
         for renderer in self.renderers:
-            self.renwin.AddRenderer(renderer)
+            self.render_window.AddRenderer(renderer)
 
-        if global_theme.depth_peeling["enabled"]:
+        # Add the shadow renderer to allow us to capture interactions within
+        # a given viewport
+        # https://vtk.org/pipermail/vtkusers/2018-June/102030.html
+        number_or_layers = self.render_window.GetNumberOfLayers()
+        current_layer = self.renderer.GetLayer()
+        self.render_window.SetNumberOfLayers(number_or_layers + 1)
+        self.render_window.AddRenderer(self.renderers.shadow_renderer)
+        self.renderers.shadow_renderer.SetLayer(current_layer + 1)
+        self.renderers.shadow_renderer.SetInteractive(False)  # never needs to capture
+        
+        self.background_color = self.theme.background
+        self._setup_interactor()
+
+        # # Add the shadow renderer to allow us to capture interactions within
+        # # a given viewport
+        # # https://vtk.org/pipermail/vtkusers/2018-June/102030.html
+        number_or_layers = self.render_window.GetNumberOfLayers()
+        current_layer = self.renderer.GetLayer()
+        self.render_window.SetNumberOfLayers(number_or_layers + 1)
+        self.render_window.AddRenderer(self.renderers.shadow_renderer)
+        self.renderers.shadow_renderer.SetLayer(current_layer + 1)
+        self.renderers.shadow_renderer.SetInteractive(False)  # never needs to capture
+
+
+        # Set window size
+        self._window_size_unset = False
+        if window_size is None:
+            self.window_size = self._theme.window_size
+            if self.window_size == pv.plotting.themes.Theme().window_size:
+                self._window_size_unset = True
+        else:
+            self.window_size = window_size
+
+        # # Set camera widget based on theme. This requires that an
+        # # interactor be present.
+        if self.theme._enable_camera_orientation_widget:
+            self.add_camera_orientation_widget()
+
+        # Set background
+        self.set_background(self._theme.background)
+
+        if self._theme.depth_peeling.enabled:
             if self.enable_depth_peeling():
                 for renderer in self.renderers:
                     renderer.enable_depth_peeling()
 
-        self._setup_interactor()
+        # set anti_aliasing based on theme
+        if self.theme.anti_aliasing:
+            self.enable_anti_aliasing(self.theme.anti_aliasing)
 
-        self._background = background
+        self._run_background = background
         self._thread = None
 
-        self._app = None
+        # self._app = None
         # Set some private attributes that let BasePlotter know
         # that this is safely rendering
         self._first_time = False  # Crucial!
+        self._initialized = True
 
     def _setup_interactor(self) -> None:
         self.iren = RenderWindowInteractor(
-            self, interactor=self.renwin.GetInteractor()
+            self, interactor=self.render_window.GetInteractor()
         )
         self.iren.interactor.RemoveObservers(
             "MouseMoveEvent"
@@ -101,6 +156,31 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
         self.deep_clean()
         if self._initialized:
             del self.renderers
+
+    @property
+    def window_size(self) -> tuple[int, int]:  # numpydoc ignore=RT01
+        """Return the render window size in ``(width, height)``.
+
+        Examples
+        --------
+        Change the window size from ``200 x 200`` to ``400 x 400``.
+
+        >>> import pyvista as pv
+        >>> pl = pv.Plotter(window_size=[200, 200])
+        >>> pl.window_size
+        [200, 200]
+        >>> pl.window_size = [400, 400]
+        >>> pl.window_size
+        [400, 400]
+
+        """
+        return tuple(self.render_window.GetSize())
+
+    @window_size.setter
+    def window_size(self, window_size):  # numpydoc ignore=GL08
+        self.render_window.SetSize(window_size[0], window_size[1])
+        self._window_size_unset = False
+        #self.render() # rendering is controlled by imgui so do not do that here!
 
     def close(self, render=False):
         """Override the BasePlotter's close method to ensure correct behavior.
@@ -146,8 +226,6 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
             if _ALL_PLOTTERS is not None:
                 _ALL_PLOTTERS.pop(self._id_name, None)
 
-        VTKImguiRenderWindowInteractor.close(self)
-
         # this helps managing closed plotters
         self._closed = True 
 
@@ -157,10 +235,15 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
         Override to ignore the 'render' argument
         """
         kwargs["render"] = False # never render as this is not controlled by vtk any more
-        pv.BasePlotter.add_actor(self, *args, **kwargs)
+        return pv.BasePlotter.add_actor(self, *args, **kwargs)
+    
+    @wraps(pv.BasePlotter.set_background)
+    def set_background(self, color, top=None, right=None, side=None, corner=None, all_renderers=True):
+        # the background color is not set unless the top color is set as well to enforce it 
+        super().set_background(color, top=top or color, right=right, side=side, corner=corner, all_renderers=all_renderers)
 
     def show(self, 
-             window_size: tuple[int, int] = (1400, 1080),
+             window_size: tuple[int, int] = None,
              before_close_callback: typ.Optional[typ.Callable] = None,
             **kwargs):
         """
@@ -178,18 +261,20 @@ class ImguiPlotter(VTKImguiRenderWindowInteractor, pv.BasePlotter):
         kwargs: Exists to ensure compatiblity with the BasePlotter interface. 
                 Any additional keywords are ignored for this plotter.
         """
-        if self._closed:
-            raise ValueError("Attempt to re-open a closed plotter")
-        
         if before_close_callback is None:
             before_close_callback = global_theme._before_close_callback
         self._before_close_callback = before_close_callback
 
+        if window_size is None:
+            window_size = self.window_size
+        else:
+            self._window_size_unset = False
+        self.render_window.SetSize(window_size[0], window_size[1])
+
         def _show():
             self.imgui_backend.show(title=self.title, window_size=window_size)
-            self.close()
 
-        if self._background:
+        if self._run_background:
             from threading import Thread
             self._thread = Thread(target=_show)
             self._thread.start()

--- a/pyvista_imgui/texture_render_window.py
+++ b/pyvista_imgui/texture_render_window.py
@@ -1,30 +1,5 @@
-# This class is a port of the integration done in the imgui-vtk library (https://github.com/trlsmax/imgui-vtk) 
-# which is available under the folloing license:
-
-# MIT License
-
-# Copyright (c) 2023 imgui-vtk Contributors
-
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
-from vtkmodules.vtkRenderingOpenGL2 import vtkGenericOpenGLRenderWindow
-from OpenGL.GL import *
+from vtkmodules.vtkRenderingOpenGL2 import vtkGenericOpenGLRenderWindow, vtkTextureObject
+from vtkmodules.vtkCommonCore import VTK_UNSIGNED_CHAR
 import typing as typ
 
 
@@ -35,71 +10,59 @@ class VTKOpenGLTextureRenderWindow(object):
     """
     Class to render the output of one or multiple vtk renderers into an opengl texture object. The texture can be retrieved for use in other visualization packages based on opengl.
     """
-    def __init__(self, 
-                 viewport_size: tuple[int, int] = (0, 0)) -> None:
+    def __init__(self) -> None:
         """
         A specialization of a vtkRenderWindow that renders itself into an opengl texture 
         when calling the 'render' method. 
         The resulting texture an be retrieved for use in external visualization packages based on opengl.
 
         The size of the resulting texture can be resized dynamically upon calling 'render'
-        Parameters
-        ----------
-        viewport_size, optional
-            the default viewport size in pixels, by default (0, 0)
         """
-        self._tex = 0
-        self._first_render = True
+  
+        self._tex = None
         self._renderers = []
 
-        self.viewport_size = viewport_size
+        self._texture_size = (0, 0)
 
         self.render_window = vtkGenericOpenGLRenderWindow()
-        self.render_window.SetSize(*self.viewport_size)
-
-        # the render window is always current as it is rendering into a texture when explicitly requested
         self.render_window.SetIsCurrent(True)
-        self.render_window.SwapBuffersOn()
-        self.render_window.SetOffScreenRendering(True)
-        self.render_window.SetFrameBlitModeToNoBlit()
-
-    def __del__(self) -> None:
-        self.close()
-
-
-    def close(self):
-        if self._tex:
-            try:
-                glDeleteTextures(1, [self._tex])
-            except:
-                pass # homehow OpenGL sometimes throws errors on shutdown so just catch them here for now
-        self._first_render = True
-        
+ 
     @property
     def texture_id(self) -> typ.Optional[int]:
         """
         Returns the texture id of the rendererd texture. 
         If nothing has been rendererd yet, None is returned instead.
         """
-        if self._first_render:
+        if self._tex is None:
             return None # no texture has been created yet
-        return self._tex
+        return self._tex.GetHandle()
+    
+    @property
+    def size(self) -> tuple[int, int]:
+        return self.render_window.GetSize()
+    
+    @size.setter
+    def size(self, size: tuple[int, int]) -> None:
+        self.render_window.SetSize(int(size[0]), int(size[1]))
 
-    def render(self, size: typ.Optional[tuple[int, int]] = None) -> None:
+    def render(self) -> None:
         """ 
-        Renders the vtk output into a texture of given size.
-
-        Parameters
-        ----------
-        size, optional
-            the size of the texture. It None (default), the current size of the internal texture is used.
+        Renders the vtk output into a texture of appropriate size.
         """
-        if size is None:
-            size = self.viewport_size
-        self.set_viewport_size(size)
+        self.set_viewport_size(self.size)
+
+        vtk_fbo = self.render_window.GetDisplayFramebuffer()
+        vtk_fbo.SetContext(self.render_window)
+        vtk_fbo.SaveCurrentBindingsAndBuffers()
+        vtk_fbo.Bind()
+        vtk_fbo.AddColorAttachment(0, self._tex)
+        vtk_fbo.AddDepthAttachment()
+        vtk_fbo.ActivateBuffer(0)
 
         self.render_window.Render()
-        self.render_window.WaitForCompletion()
+        #self.render_window.WaitForCompletion()
+
+        vtk_fbo.RestorePreviousBindingsAndBuffers()
 
     def __getattr__(self, attr):
         """
@@ -123,37 +86,32 @@ class VTKOpenGLTextureRenderWindow(object):
         new_size
             the new size of the viewport
         """
-        # skip if nothing has changed
-        if ((self.viewport_size[0] == new_size[0] and self.viewport_size[1] == new_size[1]) or 
-            new_size[0] <= 0 or new_size[1] <= 0) and not self._first_render:
-            return
 
-        self.viewport_size = new_size
         # init the internal render window to use the current (texture) context
-        self.render_window.InitializeFromCurrentContext() #IMPORTANT: initialize the current opengl context before messing with the textures!
-        self.render_window.SetSize(int(self.viewport_size[0]), int(self.viewport_size[1]))
         # create a texture object to render into
-        if not self._first_render:
-            glDeleteTextures([self._tex])
-        self._tex = glGenTextures(1)
-        glBindTexture(GL_TEXTURE_2D, self._tex)
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR)
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT)
-        glTexParameterf(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT)
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, int(self.viewport_size[0]), 
-                     int(self.viewport_size[1]), 0, GL_RGBA, GL_UNSIGNED_BYTE, None)
+        if self._tex is None:
+            # init the opengl context here
+            self.render_window.OpenGLInitContext()
+            self.render_window.OpenGLInitState()
+            self.render_window.MakeCurrent()
+
+            # setup color texture
+            self._tex = vtkTextureObject()
+            self._tex.SetContext(self.render_window)
+
+            # allocate the texture object using the initial size
+            self._tex.Create2D(new_size[0], new_size[1], 4, VTK_UNSIGNED_CHAR, False)
+            self._tex.SetWrapS(vtkTextureObject.ClampToEdge)
+            self._tex.SetWrapT(vtkTextureObject.ClampToEdge)
+            self._tex.SetMinificationFilter(vtkTextureObject.Linear)
+            self._tex.SetLinearMagnification(True)
+            self._tex.Bind()
+            self._tex.SendParameters()
+
+        current_size = self.size
+        # if nothing has changed just return
+        if current_size == new_size or any(s <= 0 for s in new_size):
+            return
         
-        glBindTexture(GL_TEXTURE_2D, 0)
-
-        for renderer in self.render_window.GetRenderers():
-            renderer.ResetCamera()
-
-        # use the texture
-        vtk_fbo = self.render_window.GetDisplayFramebuffer()
-        vtk_fbo.Bind()
-        glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, self._tex, 0)
-        vtk_fbo.UnBind()
-
-        glBindFramebuffer(GL_FRAMEBUFFER, 0)
-        self._first_render = False
+        self.size = new_size
+        self._tex.Resize(new_size[0], new_size[1])

--- a/pyvista_imgui/texture_render_window.py
+++ b/pyvista_imgui/texture_render_window.py
@@ -64,12 +64,17 @@ class VTKOpenGLTextureRenderWindow(object):
         self.render_window.SetFrameBlitModeToNoBlit()
 
     def __del__(self) -> None:
+        self.close()
+
+
+    def close(self):
         if self._tex:
             try:
                 glDeleteTextures(1, [self._tex])
             except:
                 pass # homehow OpenGL sometimes throws errors on shutdown so just catch them here for now
-
+        self._first_render = True
+        
     @property
     def texture_id(self) -> typ.Optional[int]:
         """


### PR DESCRIPTION
The `VTKOpenGLTextureRenderWindow` now renders into a custom VTK texture. This removes the dependency on the `pyopengl` package for raw calls to the OpenGL API as well as simplifying the whole texture setup. Also removes issues with rendering of text labels and opacity.